### PR TITLE
Remove walkmod plugin form base-docker-image (fixes #11)

### DIFF
--- a/base-docker-image/pom.xml
+++ b/base-docker-image/pom.xml
@@ -95,23 +95,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.walkmod.maven.plugins</groupId>
-        <artifactId>walkmod-maven-plugin</artifactId>
-        <version>1.0.3</version>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>apply</goal>
-            </goals>
-            <configuration>
-              <chains>pmd</chains>
-              <properties>configurationFile=rulesets/java/basic.xml</properties>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>2.4</version>
         <configuration>


### PR DESCRIPTION
The maven project in `base-docker-image` is used to build the required jar archive. 
The project doesn't contain any source files. 
Walkmod plugin does not give any benefits here. On the other hand, it causes dependency problems.

This PR removes the plugin.