### PR TITLE
Cleanup Docker configuration, introduce .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!src/
+!pom.xml
+!docker_run.sh
+!paramgenerator/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /opt
 RUN apt-get update
 RUN apt-get install -y bash curl maven python
-RUN curl -L 'http://archive.apache.org/dist/hadoop/core/hadoop-3.2.1/hadoop-3.2.1.tar.gz' | tar -xz
+RUN curl -L 'https://archive.apache.org/dist/hadoop/core/hadoop-3.2.1/hadoop-3.2.1.tar.gz' | tar -xz
 
 # Copy the project
 COPY . /opt/ldbc_snb_datagen

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-jdk-buster
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# Download hadoop
+# Download Hadoop
 WORKDIR /opt
 RUN apt-get update
 RUN apt-get install -y bash curl maven python
@@ -12,6 +12,8 @@ RUN curl -L 'http://archive.apache.org/dist/hadoop/core/hadoop-3.2.1/hadoop-3.2.
 COPY . /opt/ldbc_snb_datagen
 WORKDIR /opt/ldbc_snb_datagen
 
+# Fetch dependencies
+RUN mvn dependency:resolve
 # Build jar bundle
 RUN mvn -DskipTests clean assembly:assembly
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM ldbc/datagen-base:latest
+FROM openjdk:8-jdk-buster
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Download hadoop
+WORKDIR /opt
+RUN apt-get update
+RUN apt-get install -y bash curl maven python
+RUN curl -L 'http://archive.apache.org/dist/hadoop/core/hadoop-3.2.1/hadoop-3.2.1.tar.gz' | tar -xz
 
 # Copy the project
 COPY . /opt/ldbc_snb_datagen
 WORKDIR /opt/ldbc_snb_datagen
-# Remove sample parameters
-RUN rm params*.ini
+
 # Build jar bundle
 RUN mvn -DskipTests clean assembly:assembly
 
 ENV HADOOP_CLIENT_OPTS '-Xmx8G'
-ENV PATH "/opt/julia-1.2.0/bin:${PATH}"
 CMD /opt/ldbc_snb_datagen/docker_run.sh

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To grab Hadoop, extract it, and set the environment values to sensible defaults,
 
 ```bash
 cp params-csv-basic.ini params.ini
-wget http://archive.apache.org/dist/hadoop/core/hadoop-3.2.1/hadoop-3.2.1.tar.gz
+wget https://archive.apache.org/dist/hadoop/core/hadoop-3.2.1/hadoop-3.2.1.tar.gz
 tar xf hadoop-3.2.1.tar.gz
 export HADOOP_CLIENT_OPTS="-Xmx2G"
 # set this to the Hadoop 3.2.1 directory
@@ -73,7 +73,7 @@ docker build . --tag ldbc/datagen
 
 Set the `params.ini` in the repository as for the pseudo-distributed case. The file will be mounted in the container by the `--mount type=bind,source="$(pwd)/params.ini,target="/opt/ldbc_snb_datagen/params.ini"` option. If required, the source path can be set to a different path.
 
-The container outputs its results in the `/opt/ldbc_snb_datagen/out/` directory which contains two sub-directories, `social_network/` and `substitution_parameters`. In order to save the results of the generation, a directory must be mounted in the container from the host. The driver requires the results be in the datagen repository directory. To generate the data, run the following command which includes changing the owner (`chown`) of the Docker-mounted volumes.
+The container outputs its results in the `/opt/ldbc_snb_datagen/out/` directory which contains two sub-directories, `social_network/` and `substitution_parameters/`. In order to save the results of the generation, a directory must be mounted in the container from the host. The driver requires the results be in the datagen repository directory. To generate the data, run the following command which includes changing the owner (`chown`) of the Docker-mounted volumes.
 
 :warning: This removes the previously generated `social_network/` directory:
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,15 @@ Set the `params.ini` in the repository as for the pseudo-distributed case. The f
 
 The container outputs its results in the `/opt/ldbc_snb_datagen/out/` directory which contains two sub-directories, `social_network/` and `substitution_parameters`. In order to save the results of the generation, a directory must be mounted in the container from the host. The driver requires the results be in the datagen repository directory. To generate the data, run the following command which includes changing the owner (`chown`) of the Docker-mounted volumes.
 
-:warning: This removes the previously generated `social_network` directory:
+:warning: This removes the previously generated `social_network/` directory:
 
 ```bash
 rm -rf social_network/ substitution_parameters && \
-  docker run --rm --mount type=bind,source="$(pwd)/",target="/opt/ldbc_snb_datagen/out" --mount type=bind,source="$(pwd)/params.ini",target="/opt/ldbc_snb_datagen/params.ini" ldbc/datagen; \
-  sudo chown -R $USER:$USER social_network/ substitution_parameters/
+  docker run --rm \
+    --mount type=bind,source="$(pwd)/",target="/opt/ldbc_snb_datagen/out" \
+    --mount type=bind,source="$(pwd)/params.ini",target="/opt/ldbc_snb_datagen/params.ini" \
+    ldbc/datagen && \
+  sudo chown -R ${USER}:${USER} social_network/ substitution_parameters/
 ```
 
 If you need to raise the memory limit, use the `-e HADOOP_CLIENT_OPTS="-Xmx..."` parameter to override the default value. For SF1, `-Xmx2G` is recommended. For SF1000, `-Xmx370G` is sufficient.

--- a/base-docker-image/Dockerfile
+++ b/base-docker-image/Dockerfile
@@ -5,11 +5,10 @@ WORKDIR /opt
 RUN apt-get update
 RUN apt-get install -y bash curl maven python
 RUN curl -L 'http://archive.apache.org/dist/hadoop/core/hadoop-3.2.1/hadoop-3.2.1.tar.gz' | tar -xz
-RUN curl -L 'https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.2.0-linux-x86_64.tar.gz' | tar -xz
 
 # Copy the project
 COPY . /opt/ldbc_snb_datagen
 WORKDIR /opt/ldbc_snb_datagen
-# Remove sample parameters
+
 # Build jar bundle
 RUN mvn -DskipTests clean assembly:assembly


### PR DESCRIPTION
Changes:
* Added a `.dockerignore` file to keep the Dockerfile clean from directories related to IDE/CI/Git and other unused files. This fixes #13.
* Removed the base Docker image as it's an additional dependency to maintain. It didn't add much value other than saving a bit of time by grabbing an image with Hadoop and the Maven dependencies pre-packaged.
* The new base image of our Docker image is the slightly more recent `openjdk:8-jdk-buster` (previously, it was `openjdk:8-jdk-stretch`).

Despite no longer relying on a base image, the build is still pretty fast -- rebuilding locally from scratch took <2 minutes and it takes <1.5 minutes in CI:
```bash
docker system prune -a && time docker build . --tag ldbc/datagen
```