### PR TITLE
Bump Hadoop version to 3.3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     working_directory: ~/ldbc/ldbc_snb_datagen
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:2024.08.1
 
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /opt
 RUN apt-get update
 RUN apt-get install -y bash curl maven python
-RUN curl -L 'https://archive.apache.org/dist/hadoop/core/hadoop-3.2.1/hadoop-3.2.1.tar.gz' | tar -xz
+RUN curl -L 'https://archive.apache.org/dist/hadoop/core/hadoop-3.3.6/hadoop-3.3.6.tar.gz' | tar -xz
 
 # Copy the project
 COPY . /opt/ldbc_snb_datagen

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Download Hadoop
 WORKDIR /opt
 RUN apt-get update
+RUN apt-get install -y ca-certificates-java
 RUN apt-get install -y bash curl maven python
 RUN curl -L 'https://archive.apache.org/dist/hadoop/core/hadoop-3.3.6/hadoop-3.3.6.tar.gz' | tar -xz
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The data sets are available at the [SURF/CWI data repository](https://hdl.handle
 
 ### Setup
 
-This version of Datagen uses Hadoop to allow execution over multiple machines. Hadoop version 3.2.1+ is recommended.
+This version of Datagen uses Hadoop to allow execution over multiple machines. Hadoop version 3.3.6+ is recommended.
 
 ### Configuration
 
@@ -63,11 +63,11 @@ To grab Hadoop, extract it, and set the environment values to sensible defaults,
 
 ```bash
 cp params-csv-basic.ini params.ini
-wget https://archive.apache.org/dist/hadoop/core/hadoop-3.2.1/hadoop-3.2.1.tar.gz
-tar xf hadoop-3.2.1.tar.gz
+wget https://archive.apache.org/dist/hadoop/core/hadoop-3.3.6/hadoop-3.3.6.tar.gz
+tar xf hadoop-3.3.6.tar.gz
 export HADOOP_CLIENT_OPTS="-Xmx2G"
-# set this to the Hadoop 3.2.1 directory
-export HADOOP_HOME=`pwd`/hadoop-3.2.1
+# set this to the Hadoop 3.3.6 directory
+export HADOOP_HOME=`pwd`/hadoop-3.3.6
 ./run.sh
 ```
 

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -8,7 +8,7 @@ if [ ! -f /opt/ldbc_snb_datagen/params.ini ]; then
 fi
 
 # Running the generator
-/opt/hadoop-3.2.1/bin/hadoop jar /opt/ldbc_snb_datagen/target/ldbc_snb_datagen-1.0.0-jar-with-dependencies.jar /opt/ldbc_snb_datagen/params.ini
+/opt/hadoop-3.3.6/bin/hadoop jar /opt/ldbc_snb_datagen/target/ldbc_snb_datagen-1.0.0-jar-with-dependencies.jar /opt/ldbc_snb_datagen/params.ini
 
 # Cleanup
 rm -f m*personFactors*

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <version>3.2.1</version>
+      <version>3.3.6</version>
     </dependency>
     <dependency>
       <groupId>ca.umontreal.iro</groupId>

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ if [ ! -f params.ini ]; then
   exit 1
 fi
 
-DEFAULT_HADOOP_HOME=/home/user/hadoop-3.2.1 #change to your hadoop folder
+DEFAULT_HADOOP_HOME=/home/user/hadoop-3.3.6 #change to your hadoop folder
 DEFAULT_LDBC_SNB_DATAGEN_HOME=`pwd` #change to your ldbc_snb_datagen folder
 
 # allow overriding configuration from outside via environment variables


### PR DESCRIPTION
This PR bumps the Hadoop version from 3.2.1 to 3.3.6. The latter is supported by [AWS Elastic MapReduce 6.15.0 and 7.3.0](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-hadoop.html).

The MD5 checksum of the generated data is the same before and after this PR:

```bash
$ md5sum *.csv */*.csv | md5sum
79773b32a57a273025e08d6566a1e2af  -
```