### PR TITLE
Add SF3000

### DIFF
--- a/src/main/resources/scale_factors.xml
+++ b/src/main/resources/scale_factors.xml
@@ -171,6 +171,25 @@
         </property>
     </scale_factor>
 
+    <scale_factor name="snb.interactive.3000" >
+        <property>
+            <name>ldbc.snb.datagen.generator.numPersons</name>
+            <value>9200000</value>
+        </property>
+        <property>
+            <name>ldbc.snb.datagen.generator.startYear</name>
+            <value>2010</value>
+        </property>
+        <property>
+            <name>ldbc.snb.datagen.generator.numYears</name>
+            <value>3</value>
+        </property>
+        <property>
+            <name>ldbc.snb.datagen.generator.distribution.degreeDistribution</name>
+            <value>ldbc.snb.datagen.generator.distribution.FacebookDegreeDistribution</value>
+        </property>
+    </scale_factor>
+
     <scale_factor name="graphalytics.1" >
         <property>
             <name>ldbc.snb.datagen.generator.gscale</name>


### PR DESCRIPTION
This PR add the option to generate SF3000 data sets.

SF300:

```bash
du -d0 ~/social_network-sf300-CsvMergeForeign-StringDateFormatter/dynamic/
234471748       /home/ubuntu/social_network-sf300-CsvMergeForeign-StringDateFormatter/dynamic/
```

SF3000:

```bash
$ du -d0 dynamic/
2347545504      dynamic/
```

Note that generating the initial data set (90% of the 3 year period in the benchmark) requires 184 GB memory.
Generating the update stream takes more (can be as much as 1 TB, I didn't test it).